### PR TITLE
update python version

### DIFF
--- a/rl-env.yaml
+++ b/rl-env.yaml
@@ -1,9 +1,9 @@
-name: rl-testing
+name: rl-env
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.11.12=h3f84c4b_0_cpython
+  - python=3.11
   - stable-baselines3>=2.6.0
   - jupyterlab>=4.4.2
   - gymnasium>=1.0.0


### PR DESCRIPTION
Update python version to 3.11.  This allows any 3.11.xx to be installed and will install the latest available.  This is more compatible with other architectures.  Example on M1 Mac: conda env create -n rl-test --platform osx-arm64 --file rl-env.yaml - this will create all files on Mac M1.  When comlete, type conda activate rl-test to make environment active.  Once there you can run commands such as spyder to start IDE to build files.